### PR TITLE
Reverting The Plugin Dependencies Version from to 1.1 to 1.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     "targets": [
         {
             "id": "org.ekstep.questionset",
-            "ver": 1.1
+            "ver": 1.0
         }
     ],
     "editor": {
@@ -24,7 +24,7 @@
             {
                 "type": "plugin",
                 "plugin": "org.ekstep.questionunit",
-                "ver": "1.1"
+                "ver": "1.0"
             },
             {
                 "type": "js",
@@ -75,7 +75,7 @@
     "dependencies": [
         {
             "plugin": "org.ekstep.questionunit",
-            "ver": "1.1",
+            "ver": "1.0",
             "type": "plugin",
             "scope": "all"
         }


### PR DESCRIPTION
This pull request reverting the changes of Saturday Plugin Dependencies version bump up which was expected to fix the cache issue