### PR TITLE
Issue #24 fix: console error in question set

### DIFF
--- a/renderer/plugin.js
+++ b/renderer/plugin.js
@@ -48,9 +48,9 @@ org.ekstep.questionunitmcq.RendererPlugin = org.ekstep.contentrenderer.questionU
     MCQController.renderQuestion(); // eslint-disable-line no-undef
     if (this._question.state && _.has(this._question.state, 'val')) {
       this._selectedIndex = this._question.state.val;
-      $("input[name='radio']", $(this._constant.mcqParentDiv))[this._selectedIndex].checked = true; // eslint-disable-line no-undef
+      // put the logice in checkbox selection
       if (this._question.config.layout == "Horizontal") {
-        $($("input[name='radio']")[this._selectedIndex]).parents('.option').addClass('selected');
+      //put the logic if we add something in horizontal template in state save  
       }
     } else {
       this._selectedIndex = undefined;


### PR DESCRIPTION
In question set renderer the console error is showing when back on navigation because current Design no checkbox we are using 

script.min.1.10.1.792.js:15 TypeError: Cannot set property 'checked' of undefined
    at a.postQuestionShow (questionunitMCQPlugin.js:51)
    at a.showQuestion (questionUnitRenderer.js:40)
    at e.dispatch (script.min.1.10.1.792.js:57)
    at Object.dispatchEvent (script.min.1.10.1.792.js:57)
    at a.renderQuestion (questionSetRenderer.js:149)
    at a.renderPrevQuestion (questionSetRenderer.js:254)
    at a.prevQuestion (questionSetRenderer.js:247)
    at a.handlePrevious (questionSetRenderer.js:404)
    at eval (navigation.js:59)
    at e.dispatch (script.min.1.10.1.792.js:57)